### PR TITLE
ci: add kernelspec name verification to CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,6 +24,18 @@ jobs:
         run: |
           python -c "import ee; v=ee.__version__; print('ee-api:', v); assert v == '1.1.5rc0', 'Expected fork 1.1.5rc0, got ' + v"
 
+
+      - name: Verify notebook kernelspec
+        run: |
+          kernel_name=$(python3 -c "import json; nb=json.load(open('ui.ipynb')); print(nb['metadata']['kernelspec']['name'])")
+          expected="venv-coverage_analysis"
+          if [ "$kernel_name" != "$expected" ]; then
+            echo "ERROR: kernelspec name '$kernel_name' != expected '$expected'"
+            echo "SEPAL's update-app.sh installs kernels as 'venv-<app_name>'. Update ui.ipynb metadata."
+            exit 1
+          fi
+          echo "kernelspec name OK: $kernel_name"
+
       - name: Install test deps
         shell: micromamba-shell {0}
         run: pip install pytest nbmake ipykernel


### PR DESCRIPTION
## Summary
- Add kernelspec name verification step to CI workflow
- Asserts notebook kernel name matches  (the name SEPAL's  assigns)
- Prevents regressions where the kernelspec gets accidentally changed

## Test plan
- [x] CI  step passes